### PR TITLE
Allow to use a different dns server for every host

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Then, you can active the proxy mode with `PROXY_MODE=true`.<br/>
 The proxy mode will enable a nginx reverse proxy that will expose from this container some of the services that are running inside the tailscale network, that you can specify with some environment variables with this format:<br/>
 ```PROXY_HOST_[LOCAL-PORT]=[REMOTE-HOST]:[REMOTE-PORT]```<br/>
 The reverse proxy will automatically use tailscale nameserver (100.100.100.100) to resolve the REMOTE HOST. <br/>
-If you want to use a custom namesever you can specify it in the `DNS_SERVER` environment variable.
+If you want to use a custom namesever you can specify it in the `DNS_SERVER` environment variable.<br/>
+If you want to use a custom nameserver for a specific host, you can specify it in the same value like:
+```PROXY_HOST_[LOCAL-PORT]=[REMOTE-HOST]:[REMOTE-PORT]:[LOCAL-DNS-SERVER]```<br/>
 
 ### Docker
 

--- a/entrypoint
+++ b/entrypoint
@@ -23,9 +23,12 @@ setProxyMode() {
       existHosts="true";
 
       host_parts=($(echo "$value" | tr ':' '\n'))
+
+      resolver="${host_parts[2]}"
+      [ ! -z "$resolver" ] || resolver="$DNS_SERVER"
       servers+="
       server {
-          resolver $DNS_SERVER ipv6=off valid=30s;
+          resolver ${resolver} ipv6=off valid=30s;
           listen ${port};
           set \$server${port} ${host_parts[0]}:${host_parts[1]};
           proxy_pass \$server${port};


### PR DESCRIPTION
You can now specify a different dns server for every host like:
`PROXY_HOST_802=nginx.default.svc.cluster.local:80:172.20.0.10`
